### PR TITLE
Move videos from AWS to DigitalOcean

### DIFF
--- a/components/Navbar/Navbar.tsx
+++ b/components/Navbar/Navbar.tsx
@@ -14,10 +14,6 @@ const Navbar = () => {
                     priority
                 />
             </Link>
-            {/* <div className={styles.menu}>
-                <div>Meny</div>
-                <div className={styles.hamburgerMenu}></div>
-            </div> */}
         </nav>
     )
 }

--- a/components/slides/domstol/VideoSlideTech.tsx
+++ b/components/slides/domstol/VideoSlideTech.tsx
@@ -3,7 +3,7 @@ import VideoSlide from '../../common/VideoSlide';
 
 const VideoSlideTech = () => {
     return (
-        <VideoSlide src="https://s3.tebi.io/webstep/Webstep_DA_tekniskfilm_v01.mp4" autoplay={true} />
+        <VideoSlide src="https://webstep-kundehistorier.fra1.cdn.digitaloceanspaces.com/Webstep_DA_tekniskfilm_v01.mp4" autoplay={true} />
     );
 };
 

--- a/components/slides/domstol/VideoSlideWebstep.tsx
+++ b/components/slides/domstol/VideoSlideWebstep.tsx
@@ -3,7 +3,7 @@ import VideoSlide from '../../common/VideoSlide';
 
 const VideoSlideWebstep = () => {
     return (
-        <VideoSlide src="https://s3.tebi.io/webstep/Webstep_DA_hovedfilm_v01_utentekst.mp4"
+        <VideoSlide src="https://webstep-kundehistorier.fra1.cdn.digitaloceanspaces.com/Webstep_DA_hovedfilm_v01_utentekst.mp4"
             autoplay={true} landscape />
     );
 };


### PR DESCRIPTION
**Why?**

- Junior Consulting is going through the cloud services they use and is making an effort to centralize what can be centralized. This includes shutting down our AWS account, and thus moving the files hosted in S3 buckets to DigitalOcean Spaces.

**EDIT**

- Upon further inspection, I see that the videos in question are hosted through AWS CloudFront. This is moved to DigitalOcean Spaces + enabling their CDN service to achieve the same effect as S3 + CloudFront.

**Changelog**

- Move 2 videos used in Webstep Kundehistorier to fetch from DigitalOcean Spaces instead of AWS S3.

**How to test**

- Navigate to the landing page
- Ensure the videos "hovedfilm" and "teknisk film" still render as expected. These are the two videos located after scrolling a bit, each respective video above and below the number stats labeled as "Personer fikk en straffereaksjon i 2020".

**Screenshots**

### Hovedfilm

<img width="2032" alt="Screenshot 2024-12-28 at 10 28 52" src="https://github.com/user-attachments/assets/51fa4fb1-a59b-4e2c-9b6f-2c8ec806355b" />

### Teknisk film

<img width="2032" alt="Screenshot 2024-12-28 at 10 29 19" src="https://github.com/user-attachments/assets/7553f347-ac20-4ae9-86d8-b225eb81e8d9" />
